### PR TITLE
Display a progress bar during PDF import

### DIFF
--- a/src/apps/import-pdf.ts
+++ b/src/apps/import-pdf.ts
@@ -617,11 +617,26 @@ export class ImportPDFApplication extends FormApplication<ImportPDFData> {
 			e.preventDefault();
 			this.object.inProgress = true;
 			this.render();
-			for (const p of this.object.parseResults) {
+			const label = "Importing Fabula Ultima PDF";
+			SceneNavigation.displayProgressBar({
+				label,
+				pct: 0,
+			});
+			for (let i = 0; i < this.object.parseResults.length; i++) {
+				const p = this.object.parseResults[i];
 				if (p.type === "success") {
 					await p.save(this.object.imagePath);
+					const percent: number = Math.round((i / this.object.parseResults.length) * 100);
+					SceneNavigation.displayProgressBar({
+						label,
+						pct: percent,
+					});
 				}
 			}
+			SceneNavigation.displayProgressBar({
+				label,
+				pct: 100,
+			});
 			this.close();
 		});
 	}

--- a/src/external/project-fu.ts
+++ b/src/external/project-fu.ts
@@ -32,6 +32,15 @@ declare global {
 			options?: { notify?: boolean },
 		): Promise<null | false | Response | Record<string, never>>;
 	};
+	const SceneNavigation: {
+		/**
+		 * Display progress of some major operation like loading Scene textures.
+		 * @param {object} [options={}] Options for how the progress bar is displayed
+		 * @param {string} [options.label] A text label to display
+		 * @param {number} [options.pct] A percentage of progress between 0 and 100
+		 */
+		displayProgressBar(options?: { label: string; pct: number }): void;
+	};
 	class FormApplication<T> {
 		constructor(object?: T, options?: unknown);
 		render(force?: boolean): FormApplication<T>;


### PR DESCRIPTION
## Context

Importing a PDF can take some time. During that time, the only feedback
available is in the console. Rather than force folks to look there and
infer how it's going, we add a progress bar to show in the UI how things
are going.

## Testing

Not sure how to validate that this works other than loading it up in
FoundryVTT and trying an import. It should show a progress bar at the
top while importing the PDF, and then go away once the PDF import is
done.
