### PR TITLE
Make `Consumable` consistent with other equipment

### DIFF
--- a/src/pdf/parsers/consumablePage.test.ts
+++ b/src/pdf/parsers/consumablePage.test.ts
@@ -41,12 +41,11 @@ test("parses generated", () => {
 				watermark,
 			];
 			const parses = consumablesPage([pageTokens, 0]);
-			const expected: [string, Consumable[]][] = cs.map(([h, vs]) => [
-				h,
-				vs.map((v) => {
-					return { ...v, description: prettifyStrings(v.description), name: v.name.join(" ") };
+			const expected: Consumable[] = cs.flatMap(([h, vs]): Consumable[] =>
+				vs.map((v): Consumable => {
+					return { ...v, category: h, description: prettifyStrings(v.description), name: v.name.join(" ") };
 				}),
-			]);
+			);
 			const successful = parses.filter(isResult);
 			for (const p of successful) {
 				expect(p.result[0]).toEqual(expected);


### PR DESCRIPTION
## Context

`Consumable` looks to be the only type of equipment with a category that
didn't have its category in it. To make it more consistent with the
other equipment, we put the category in `Consumable`.

This change lets the `Wrapper` type become simpler, since it doesn't
need to account for this one different case.

Also, since we don't have to account for results coming back in
different shapes, we don't have to worry about handling the different
cases in `flatMap`, and can use `Array.flat` instead.

## Testing

The `src/pdf/parsers/consumablePage.test.ts` change doesn't change the
data generation. It only changes how it's munged into something we can
test against. If that test is passing, that should give decent
confidence that we haven't broken the basic behavior.

The `src/apps/import-pdf.ts` change seems to only be able to be
validated by loading up FoundryVTT and validating that `Consumable`s are
still imported properly.
