### PR TITLE
Support Core Rulebook 1.02

### DIFF
--- a/src/apps/import-pdf.ts
+++ b/src/apps/import-pdf.ts
@@ -485,7 +485,9 @@ type ParseResult = { page: number } & (
 const pr = (z: string | StringToken) => (typeof z === "string" ? z : `<Text str="${z.string}" font="${z.font}">`);
 
 const parsePdf = async (pdfPath: string): Promise<[ParseResult[], () => Promise<void>]> => {
-	const [withPage, destroy] = await tokenizePDF(pdfPath);
+	const [withPage, destroy] = await tokenizePDF({
+		url: pdfPath,
+	});
 
 	return [
 		await Promise.all(

--- a/src/pdf/lexers/pdf.ts
+++ b/src/pdf/lexers/pdf.ts
@@ -7,6 +7,13 @@ export const tokenizePDF = async (
 ): Promise<
 	[<R>(pageNum: number, f: (d: Token[]) => Promise<R>) => Promise<[R, () => boolean]>, () => Promise<void>]
 > => {
+	parameters.cMapPacked ??= true;
+	if (typeof window !== "undefined" && window?.document != null) {
+		parameters.cMapUrl ??= `//cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjsLib.version}/cmaps/`;
+	} else {
+		parameters.cMapUrl ??= "node_modules/pdfjs-dist/cmaps/";
+	}
+
 	const doc = await pdfjsLib.getDocument(parameters).promise;
 
 	return [

--- a/src/pdf/lexers/pdf.ts
+++ b/src/pdf/lexers/pdf.ts
@@ -1,13 +1,13 @@
 import * as pdfjsLib from "pdfjs-dist";
 import { Image, Token } from "./token";
-import { DocumentInitParameters, TypedArray } from "pdfjs-dist/types/src/display/api";
+import { DocumentInitParameters } from "pdfjs-dist/types/src/display/api";
 
 export const tokenizePDF = async (
-	docId: string | URL | TypedArray | ArrayBuffer | DocumentInitParameters,
+	parameters: DocumentInitParameters,
 ): Promise<
 	[<R>(pageNum: number, f: (d: Token[]) => Promise<R>) => Promise<[R, () => boolean]>, () => Promise<void>]
 > => {
-	const doc = await pdfjsLib.getDocument(docId).promise;
+	const doc = await pdfjsLib.getDocument(parameters).promise;
 
 	return [
 		async <R>(pageNum: number, f: (d: Token[]) => Promise<R>): Promise<[R, () => boolean]> => {

--- a/src/pdf/parsers/lib.ts
+++ b/src/pdf/parsers/lib.ts
@@ -150,7 +150,7 @@ export const description = alt(
 
 export const starting = seq(image, image, many1(str));
 
-export const sep = textWithFont("w", [/Wingdings-Regular$/]);
+export const sep = alt(textWithFont("w", [/Wingdings-Regular$/]), textWithFont("", [/Wingdings-Regular$/]));
 export const matches = (r: RegExp, errorMsg: string) =>
 	fmap(satisfy((t) => isStringToken(t) && r.test(t.string), errorMsg) as Parser<StringToken>, (t) => t.string);
 


### PR DESCRIPTION
## Context

Reviewing this commit-by-commit explains the changes a bit more
in-depth.

The long and short is that Core Rulebook 1.02 changed some of the fonts,
so we update things to support those new fonts.

## Testing

This can be validated one of two ways:
1. Changing the `FABULA_ULTIMA_PDF_PATH` variable in
    `src/pdf/parsers/fabula-ultma-pdf.test.ts` to point to the Core
    Rulebook 1.02, and then running the tests with `npm run test`.
2. Loading this up in FoundryVTT and importing the Core Rulebook 1.02.
    It should load all the same stuff as the previous version of the
    Core Rulebook.
