### PR TITLE
Use `Array.prototype.flatMap`

### DIFF
--- a/src/apps/import-pdf.ts
+++ b/src/apps/import-pdf.ts
@@ -1,5 +1,5 @@
 import * as pdfjsLib from "pdfjs-dist";
-import { Affinity, Parser, Stat, flatMap, isError, isResult } from "../pdf/parsers/lib";
+import { Affinity, Parser, Stat, isError, isResult } from "../pdf/parsers/lib";
 import { Consumable, consumablesPage } from "../pdf/parsers/consumablePage";
 import { Weapon, basicWeapons, rareWeapons } from "../pdf/parsers/weaponPage";
 import { Armor, armorPage } from "../pdf/parsers/armorPage";
@@ -501,10 +501,10 @@ const parsePdf = async (pdfPath: string): Promise<[ParseResult[], () => Promise<
 							return {
 								type: "success" as const,
 								page: pageNum,
-								results: flatMap<{ name: string } | [string, { name: string }[]], { name: string }>(
-									successes[0].result[0],
-									(v) => ("name" in v ? [v] : v[1]),
-								),
+								results: successes[0].result[0].flatMap<
+									{ name: string } | [string, { name: string }[]],
+									{ name: string }
+								>((v) => ("name" in v ? [v] : v[1])),
 								save: async (imagePath: string) =>
 									await save(successes[0].result[0], pageNum, folders, imagePath),
 							};

--- a/src/pdf/parsers/accessoryPage.test.ts
+++ b/src/pdf/parsers/accessoryPage.test.ts
@@ -1,6 +1,6 @@
 import fc from "fast-check";
 import { cost, description, word } from "../arbs/arbs";
-import { flatMap, isResult, prettifyStrings } from "./lib";
+import { isResult, prettifyStrings } from "./lib";
 import { Image, Token } from "../lexers/token";
 import { imageToken, stringToken, watermark } from "../arbs/output";
 import { Accessory, accessories } from "./accessoryPage";
@@ -23,7 +23,7 @@ test("parses generated", () => {
 				imageToken({ width: 0, height: 0 } as Image),
 				stringToken(""),
 
-				...flatMap(data, (m) => [
+				...data.flatMap((m) => [
 					imageToken(m.image),
 					stringToken(m.name),
 					stringToken(m.cost.toString(), "FBDLWO+PTSans-Narrow"),

--- a/src/pdf/parsers/armorPage.test.ts
+++ b/src/pdf/parsers/armorPage.test.ts
@@ -1,6 +1,6 @@
 import fc from "fast-check";
 import { cost, description, word } from "../arbs/arbs";
-import { flatMap, isResult, prettifyStrings } from "./lib";
+import { isResult, prettifyStrings } from "./lib";
 import { Image, Token } from "../lexers/token";
 import { imageToken, stringToken, watermark } from "../arbs/output";
 import { Armor, armorPage } from "./armorPage";
@@ -27,7 +27,7 @@ test("parses generated", () => {
 				imageToken({ width: 0, height: 0 } as Image),
 				stringToken(""),
 
-				...flatMap(data, (m) => [
+				...data.flatMap((m) => [
 					imageToken(m.image),
 					stringToken(m.name),
 					...(m.martial ? [stringToken("E", "FnT_BasicShapes1")] : []),

--- a/src/pdf/parsers/beastiaryPage.test.ts
+++ b/src/pdf/parsers/beastiaryPage.test.ts
@@ -2,7 +2,7 @@ import fc from "fast-check";
 import { description, resistance, descriptionEnd, word } from "../arbs/arbs";
 import { imageToken, stringToken, watermark } from "../arbs/output";
 import { Image, Token } from "../lexers/token";
-import { DAMAGE_TYPES, DIE_SIZES, Distance, STATS, flatMap, isResult, prettifyStrings, TYPE_CODES } from "./lib";
+import { DAMAGE_TYPES, DIE_SIZES, Distance, STATS, isResult, prettifyStrings, TYPE_CODES } from "./lib";
 import { Beast, beastiary } from "./beastiaryPage";
 
 const beastiaryDataGen = fc.array(
@@ -93,7 +93,7 @@ test("parses generated", () => {
 				imageToken({ width: 0, height: 0 } as Image),
 				imageToken({ width: 0, height: 0 } as Image),
 				stringToken(""),
-				...flatMap(cs, (b) => [
+				...cs.flatMap((b) => [
 					imageToken(b.image),
 					stringToken(b.name),
 					stringToken(`Lv ${b.level}`),
@@ -115,7 +115,7 @@ test("parses generated", () => {
 					stringToken(`Init. ${b.attributes.init}`),
 					stringToken(`DEF +${b.attributes.def}`),
 					stringToken(`M.DEF +${b.attributes.mdef}`),
-					...flatMap(DAMAGE_TYPES, (k) => {
+					...DAMAGE_TYPES.flatMap((k) => {
 						const resist = b.resists[k];
 						if (resist != null) {
 							const tok = stringToken(TYPE_CODES[k]);
@@ -128,7 +128,7 @@ test("parses generated", () => {
 						? []
 						: [stringToken("Equipment:"), stringToken(b.equipment.join(", ") + ".")]),
 					stringToken("BASIC ATTACKS"),
-					...flatMap(b.attacks, (a) => [
+					...b.attacks.flatMap((a) => [
 						...(a.range == "melee"
 							? [stringToken("$", "DHVFUS+Evilz")]
 							: [stringToken("a", "QTFAUS+fabulaultima"), stringToken("a", "QTFAUS+fabulaultima")]),
@@ -149,7 +149,7 @@ test("parses generated", () => {
 						? []
 						: [
 								stringToken("SPELLS"),
-								...flatMap(b.spells, (spell) => [
+								...b.spells.flatMap((spell) => [
 									stringToken("h", "DHVFUS+Evilz"),
 									stringToken(spell.name),
 									...(spell.accuracy == null
@@ -185,7 +185,7 @@ test("parses generated", () => {
 						? []
 						: [
 								stringToken("OTHER ACTIONS"),
-								...flatMap(b.otherActions, (oa) => [
+								...b.otherActions.flatMap((oa) => [
 									stringToken("S", "MNCCQA+WebSymbols-Regular"),
 									stringToken(oa.name, "WTLEAG+PTSans-NarrowBold"),
 									stringToken("w", "XFYKOE+Wingdings-Regular"),
@@ -196,7 +196,7 @@ test("parses generated", () => {
 						? []
 						: [
 								stringToken("SPECIAL RULES"),
-								...flatMap(b.specialRules, (sr) => [
+								...b.specialRules.flatMap((sr) => [
 									stringToken(sr.name),
 									stringToken("w", "XFYKOE+Wingdings-Regular"),
 									...sr.description.map((s) => stringToken(s, "FBDLWO+PTSans-Narrow")),

--- a/src/pdf/parsers/consumablePage.test.ts
+++ b/src/pdf/parsers/consumablePage.test.ts
@@ -1,6 +1,6 @@
 import fc from "fast-check";
 import { cost, multiString, word, description } from "../arbs/arbs";
-import { flatMap, isResult, prettifyStrings } from "./lib";
+import { isResult, prettifyStrings } from "./lib";
 import { Image, Token } from "../lexers/token";
 import { imageToken, stringToken, watermark } from "../arbs/output";
 import { Consumable, consumablesPage } from "./consumablePage";
@@ -28,9 +28,9 @@ test("parses generated", () => {
 				imageToken({ width: 0, height: 0 } as Image),
 				imageToken({ width: 0, height: 0 } as Image),
 				stringToken(""),
-				...flatMap(cs, ([h, d]) => [
+				...cs.flatMap(([h, d]) => [
 					stringToken(h),
-					...flatMap(d, (m) => [
+					...d.flatMap((m) => [
 						imageToken(m.image),
 						...m.name.map((s) => stringToken(s)),
 						stringToken(m.ipCost.toString()),

--- a/src/pdf/parsers/lib.ts
+++ b/src/pdf/parsers/lib.ts
@@ -39,18 +39,16 @@ export const satisfy =
 		}
 		return fail<Token>(reason)(ptr);
 	};
-export const flatMap = <T, R>(arr: readonly T[], fn: (v: T) => R[]) =>
-	arr.reduce((arr, x) => arr.concat(fn(x)), <R[]>[]);
 
 export const then =
 	<R, S>(first: Parser<R>, second: Parser<S>): Parser<[R, S]> =>
 	(i) => {
-		return flatMap(first(i), (parse) => {
+		return first(i).flatMap((parse) => {
 			if (isError(parse)) {
 				return [parse];
 			} else {
 				const [r, remainder] = parse.result;
-				return flatMap(second(remainder), (z) => {
+				return second(remainder).flatMap((z) => {
 					if (isError(z)) {
 						return [z];
 					}

--- a/src/pdf/parsers/sheildPage.test.ts
+++ b/src/pdf/parsers/sheildPage.test.ts
@@ -1,6 +1,6 @@
 import fc from "fast-check";
 import { cost, description, word } from "../arbs/arbs";
-import { flatMap, isResult, prettifyStrings } from "./lib";
+import { isResult, prettifyStrings } from "./lib";
 import { Image, Token } from "../lexers/token";
 import { imageToken, stringToken, watermark } from "../arbs/output";
 import { Shield, shieldPage } from "./shieldPage";
@@ -27,7 +27,7 @@ test("parses generated", () => {
 				imageToken({ width: 0, height: 0 } as Image),
 				stringToken(""),
 
-				...flatMap(data, (m) => [
+				...data.flatMap((m) => [
 					imageToken(m.image),
 					stringToken(m.name),
 					...(m.martial ? [stringToken("E", "FnT_BasicShapes1")] : []),

--- a/src/pdf/parsers/weaponPage.test.ts
+++ b/src/pdf/parsers/weaponPage.test.ts
@@ -1,6 +1,6 @@
 import fc from "fast-check";
 import { cost, word, description } from "../arbs/arbs";
-import { DAMAGE_TYPES, DISTANCES, HANDED, STATS, WEAPON_CATEGORIES, flatMap, isResult, prettifyStrings } from "./lib";
+import { DAMAGE_TYPES, DISTANCES, HANDED, STATS, WEAPON_CATEGORIES, isResult, prettifyStrings } from "./lib";
 import { Image, Token } from "../lexers/token";
 import { imageToken, stringToken, watermark } from "../arbs/output";
 import { Weapon, rareWeapons } from "./weaponPage";
@@ -29,7 +29,7 @@ test("rare weapon parses generated", () => {
 				stringToken(""),
 				stringToken(`SAMPLE RARE ${category} WEAPONS`),
 				stringToken(""),
-				...flatMap(d, (m) => [
+				...d.flatMap((m) => [
 					imageToken(m.image),
 					stringToken(m.name),
 					...(m.martial ? [stringToken("E", "FnT_BasicShapes1")] : []),


### PR DESCRIPTION
## Context

`Array.prototype.flatMap` has existed since ES2019:
https://tc39.es/proposal-flatMap/. That's been around longer than this
project, and indeed longer than Fabula Ultima itself. Moreover, this
project has targetted ESNext since its initial commit in 2023. So it
would be compiling to something that supports `Array.prototype.flatMap`
natively. Finally, the Fultimator import uses `Array.prototype.flatMap`
in quite a few places.

We remove the `flatMap` helper from the parsers package, and use
`Array.prototype.flatMap` directly.

## Testing

The tests passing should provide enough confidence that this is working
appropriately.