### PR TITLE
Allow selecting PDF type

### DIFF
--- a/src/apps/import-pdf.ts
+++ b/src/apps/import-pdf.ts
@@ -9,7 +9,7 @@ import { Beast } from "../pdf/parsers/beastiaryPage";
 import { StringToken, Token } from "../pdf/lexers/token";
 import { tokenizePDF } from "../pdf/lexers/pdf";
 import { ATTR, FUActor, FUItem, getFolder, saveImage } from "../external/project-fu";
-import { PageContent, PageContentType, pageContent, pageContentParser } from "../pdf/parsers/fabula-ultima-pdf";
+import { PageContent, PageContentType, pageContentParser, pdf } from "../pdf/parsers/fabula-ultima-pdf";
 
 // Relative url that foundry serves for the compiled webworker
 pdfjsLib.GlobalWorkerOptions.workerSrc = "modules/fu-parser/pdf.worker.js";
@@ -499,6 +499,7 @@ type ParseResult = { page: number } & (
 const pr = (z: string | StringToken) => (typeof z === "string" ? z : `<Text str="${z.string}" font="${z.font}">`);
 
 const parsePdf = async (pdfPath: string): Promise<[ParseResult[], () => Promise<void>]> => {
+	const pageContent: Map<number, PageContent> = pdf["Core Rulebook"];
 	const [withPage, destroy] = await tokenizePDF({
 		url: pdfPath,
 	});

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,16 @@ Hooks.on("renderSettings", async (_app, $html) => {
 		importPDFButton.append("Import PDF");
 		importPDFButton.addEventListener("click", () => {
 			const application = new ImportPDFApplication(
-				{ pdfPath: "", imagePath: "", parseResults: [], inProgress: false },
+				{
+					pdfName: "Core Rulebook",
+					pdfNames: {
+						"Core Rulebook": "Core Rulebook",
+					},
+					pdfPath: "",
+					imagePath: "",
+					parseResults: [],
+					inProgress: false,
+				},
 				{
 					width: 450,
 					height: 600,

--- a/src/pdf/parsers/fabula-ultima-pdf.test.ts
+++ b/src/pdf/parsers/fabula-ultima-pdf.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "@jest/globals";
 import fs from "fs";
 import { tokenizePDF } from "../lexers/pdf";
 import { Parser, isResult } from "./lib";
-import { pageContent, PageContent, pageContentParser, PageContentType } from "./fabula-ultima-pdf";
+import { PageContent, pageContentParser, PageContentType, pdf } from "./fabula-ultima-pdf";
 
 const STANDARD_FONT_DATA_URL = "node_modules/pdfjs-dist/standard_fonts/";
 const FABULA_ULTIMA_PDF_PATH = "data/Fabula_Ultima_-_Core_Rulebook.pdf";
@@ -25,6 +25,7 @@ const pageContentName: Record<PageContent, string> = {
 };
 
 describe("parses pages", () => {
+	const pageContent: Map<number, PageContent> = pdf["Core Rulebook"];
 	for (const [page, content] of pageContent) {
 		const f: Parser<PageContentType[typeof content][]> = pageContentParser[content];
 		const name: string = pageContentName[content];

--- a/src/pdf/parsers/fabula-ultima-pdf.ts
+++ b/src/pdf/parsers/fabula-ultima-pdf.ts
@@ -32,7 +32,7 @@ export type PageContentType = {
 	"Rare Weapon": Weapon;
 };
 
-export const pageContent: Map<number, PageContent> = new Map([
+const coreRulebookPageContent: Map<number, PageContent> = new Map([
 	[106, "Consumable"],
 	[132, "Basic Weapon"],
 	[133, "Basic Weapon"],
@@ -98,4 +98,12 @@ export const pageContentParser: {
 	"Rare Armor": armorPage,
 	"Rare Shield": shieldPage,
 	"Rare Weapon": rareWeapons,
+};
+
+export type PDFName = (typeof PDF_NAME)[number];
+
+const PDF_NAME = ["Core Rulebook"] as const;
+
+export const pdf: Record<PDFName, Map<number, PageContent>> = {
+	"Core Rulebook": coreRulebookPageContent,
 };

--- a/src/templates/import-pdf.hbs
+++ b/src/templates/import-pdf.hbs
@@ -3,6 +3,8 @@
         <div style="flex: 0 1">
             <div>
                 <div style="display:grid; grid-template-columns: 75% 20%; grid-gap: 10px 5%">
+                    <div>PDF Type</div>
+                    <div><select name="pdfName">{{ selectOptions pdfNames selected=pdfName }}</select></div>
                     <div><input type="text" name="pdfPath" placeholder="Path to your pdf" value="{{pdfPath}}"/></div>
                     <div>{{ filePicker type="pdf" target="pdfPath"}}</div>
                     <div><input type="text" name="imagePath" placeholder="Path to save images" value="{{imagePath}}"/></div>


### PR DESCRIPTION
## Context

Reviewing commit-by-commit tells the story in more depth.

We want to start supporting more than one PDF. In order to do that, it's
a little easier if we can explicitly call out which PDF we're working
with.

Since there doesn't really seem to be a definitive way to determine
which type of PDF we're supposed to be importing, we take the easy way
out and require the person importing the PDF to choose which type of PDF
it is.

Right now, it's defaulted to the Core Rulebook. And the only option is
to select the Core Rulebook. We'll add more types of PDFs and then be
able to import them (with their different pages and structure and
whatever else).

## Testing

The easiest way to validate that this works is to load this up in
Foundry, and import a PDF. This should all work as before.
