### PR TITLE
Test both Core Rulebook versions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -61,6 +61,7 @@ Hooks.on("renderSettings", async (_app, $html) => {
 					pdfName: "Core Rulebook",
 					pdfNames: {
 						"Core Rulebook": "Core Rulebook",
+						"Core Rulebook 1.02": "Core Rulebook 1.02",
 					},
 					pdfPath: "",
 					imagePath: "",

--- a/src/pdf/lexers/pdf.ts
+++ b/src/pdf/lexers/pdf.ts
@@ -2,11 +2,11 @@ import * as pdfjsLib from "pdfjs-dist";
 import { Image, Token } from "./token";
 import { DocumentInitParameters } from "pdfjs-dist/types/src/display/api";
 
-export const tokenizePDF = async (
-	parameters: DocumentInitParameters,
-): Promise<
-	[<R>(pageNum: number, f: (d: Token[]) => Promise<R>) => Promise<[R, () => boolean]>, () => Promise<void>]
-> => {
+export type Destroy = () => Promise<void>;
+
+export type WithPDF = <R>(pageNum: number, f: (d: Token[]) => Promise<R>) => Promise<[R, () => boolean]>;
+
+export const tokenizePDF = async (parameters: DocumentInitParameters): Promise<[WithPDF, Destroy]> => {
 	parameters.cMapPacked ??= true;
 	if (typeof window !== "undefined" && window?.document != null) {
 		parameters.cMapUrl ??= `//cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjsLib.version}/cmaps/`;

--- a/src/pdf/parsers/fabula-ultima-pdf.test.ts
+++ b/src/pdf/parsers/fabula-ultima-pdf.test.ts
@@ -13,7 +13,6 @@ const isENOENT = (x: unknown): x is { code: "ENOENT" } => {
 };
 
 const STANDARD_FONT_DATA_URL = "node_modules/pdfjs-dist/standard_fonts/";
-const FABULA_ULTIMA_PDF_PATH = "data/Fabula_Ultima_-_Core_Rulebook.pdf";
 
 const tokenize = async (filePath: string): Promise<[WithPDF, Destroy] | null> => {
 	try {
@@ -30,7 +29,10 @@ const tokenize = async (filePath: string): Promise<[WithPDF, Destroy] | null> =>
 	}
 };
 
-const tokenizedCoreRulebook: [WithPDF, Destroy] | null = await tokenize(FABULA_ULTIMA_PDF_PATH);
+const tokenizedCoreRulebook: [WithPDF, Destroy] | null = await tokenize("data/Fabula_Ultima_-_Core_Rulebook.pdf");
+const tokenizedCoreRulebook_1_02: [WithPDF, Destroy] | null = await tokenize(
+	"data/Fabula_Ultima_-_Core_Rulebook_1.02.pdf",
+);
 
 const pageContentName: Record<PageContent, string> = {
 	Accessory: "Accessories",
@@ -50,10 +52,8 @@ type DescribePDF = {
 };
 
 describe.each<DescribePDF>([
-	{
-		name: "Core Rulebook",
-		tokenized: tokenizedCoreRulebook,
-	},
+	{ name: "Core Rulebook", tokenized: tokenizedCoreRulebook },
+	{ name: "Core Rulebook 1.02", tokenized: tokenizedCoreRulebook_1_02 },
 ])("parses pages for $name", (describePDF: DescribePDF): void => {
 	if (describePDF.tokenized == null) {
 		return;

--- a/src/pdf/parsers/fabula-ultima-pdf.test.ts
+++ b/src/pdf/parsers/fabula-ultima-pdf.test.ts
@@ -26,16 +26,29 @@ const pageContentName: Record<PageContent, string> = {
 
 describe("parses pages", () => {
 	const pageContent: Map<number, PageContent> = pdf["Core Rulebook"];
-	for (const [page, content] of pageContent) {
+	type PageContentWithName = {
+		content: PageContent;
+		name: string;
+		page: number;
+	};
+	const pageContentWithName: PageContentWithName[] = [...pageContent].map(
+		([page, content]: [number, PageContent]): PageContentWithName => {
+			return {
+				content,
+				name: pageContentName[content],
+				page,
+			};
+		},
+	);
+	test.each(pageContentWithName)(`$page - $name`, async (pageContentWithName: PageContentWithName): Promise<void> => {
+		const content: PageContent = pageContentWithName.content;
+		const page: number = pageContentWithName.page;
 		const f: Parser<PageContentType[typeof content][]> = pageContentParser[content];
-		const name: string = pageContentName[content];
-		test(`${page} - ${name}`, async () => {
-			await withPage(page, async (d) => {
-				const successful = f([d, 0]).filter(isResult);
-				expect(successful.length).toBe(1);
-			});
+		await withPage(page, async (d) => {
+			const successful = f([d, 0]).filter(isResult);
+			expect(successful.length).toBe(1);
 		});
-	}
+	});
 
 	// test("current", async () => {
 	// 	await withPage(350, async (d) => {

--- a/src/pdf/parsers/fabula-ultima-pdf.test.ts
+++ b/src/pdf/parsers/fabula-ultima-pdf.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from "@jest/globals";
 import fs from "fs";
-import { tokenizePDF } from "../lexers/pdf";
+import { Destroy, tokenizePDF, WithPDF } from "../lexers/pdf";
 import { Parser, isResult } from "./lib";
-import { PageContent, pageContentParser, PageContentType, pdf } from "./fabula-ultima-pdf";
+import { PageContent, pageContentParser, PageContentType, pdf, PDFName } from "./fabula-ultima-pdf";
 
 const STANDARD_FONT_DATA_URL = "node_modules/pdfjs-dist/standard_fonts/";
 const FABULA_ULTIMA_PDF_PATH = "data/Fabula_Ultima_-_Core_Rulebook.pdf";
 
-const [withPage, destroy] = await tokenizePDF({
+const tokenizedCoreRulebook: [WithPDF, Destroy] = await tokenizePDF({
 	data: new Uint8Array(fs.readFileSync(FABULA_ULTIMA_PDF_PATH)),
 	standardFontDataUrl: STANDARD_FONT_DATA_URL,
 });
@@ -24,8 +24,19 @@ const pageContentName: Record<PageContent, string> = {
 	"Rare Weapon": "Weapons - Rare",
 };
 
-describe("parses pages", () => {
-	const pageContent: Map<number, PageContent> = pdf["Core Rulebook"];
+type DescribePDF = {
+	name: PDFName;
+	tokenized: [WithPDF, Destroy];
+};
+
+describe.each<DescribePDF>([
+	{
+		name: "Core Rulebook",
+		tokenized: tokenizedCoreRulebook,
+	},
+])("parses pages for $name", (describePDF: DescribePDF): void => {
+	const [withPage, destroy]: [WithPDF, Destroy] = describePDF.tokenized;
+	const pageContent: Map<number, PageContent> = pdf[describePDF.name];
 	type PageContentWithName = {
 		content: PageContent;
 		name: string;

--- a/src/pdf/parsers/fabula-ultima-pdf.ts
+++ b/src/pdf/parsers/fabula-ultima-pdf.ts
@@ -102,8 +102,9 @@ export const pageContentParser: {
 
 export type PDFName = (typeof PDF_NAME)[number];
 
-const PDF_NAME = ["Core Rulebook"] as const;
+const PDF_NAME = ["Core Rulebook", "Core Rulebook 1.02"] as const;
 
 export const pdf: Record<PDFName, Map<number, PageContent>> = {
 	"Core Rulebook": coreRulebookPageContent,
+	"Core Rulebook 1.02": coreRulebookPageContent,
 };


### PR DESCRIPTION
## Context

Reviewing commit-by-commit tells the story in more depth.

The long and short is that we change the
`src/pdf/parsers/fabula-ultima-pdf.test.ts` test file to test not only
the original Core Rulebook, but also the 1.02 version of the Core
Rulebook. If either one doesn't exist, we ignore that fact, since not
everyone will have both Core Rulebooks. If neither exist, it has similar
behavior as before: fail the test suite.

## Testing

If the tests pass, this should give us enough confidence that this works
properly.
